### PR TITLE
NP-1477: Reserved concurrent executions

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -106,5 +106,3 @@ Outputs:
   CognitoPostAuthenticationFunction:
     Description: ARN Identifier of the PostAuthenticationTrigger
     Value: !GetAtt PostAuthenticationTrigger.Arn
-    Export:
-      Name: CognitoPostAuthenticationFunctionArnV2

--- a/template.yaml
+++ b/template.yaml
@@ -90,7 +90,8 @@ Resources:
       Role: !GetAtt TriggerExecutionRole.Arn
       MemorySize: 1408
       Timeout: 10
-      ReservedConcurrentExecutions: 3
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 3
       Environment:
         Variables:
           CUSTOMER_API_SCHEME: https

--- a/template.yaml
+++ b/template.yaml
@@ -90,6 +90,7 @@ Resources:
       Role: !GetAtt TriggerExecutionRole.Arn
       MemorySize: 1408
       Timeout: 10
+      ReservedConcurrentExecutions: 3
       Environment:
         Variables:
           CUSTOMER_API_SCHEME: https

--- a/template.yaml
+++ b/template.yaml
@@ -92,6 +92,7 @@ Resources:
       Timeout: 10
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: 3
+      AutoPublishAlias: live
       Environment:
         Variables:
           CUSTOMER_API_SCHEME: https


### PR DESCRIPTION
Ensure the post authentication function for Cognito is always warm to
avoid it hitting timeout when trying to hit our post authentication
function.

It should hopefully be a work-around for
https://unit.atlassian.net/browse/NP-1477 to avoid broken logins.